### PR TITLE
Take control of instances of injected driver.

### DIFF
--- a/source/browser/driver.js
+++ b/source/browser/driver.js
@@ -35,7 +35,7 @@ function _open(browserName, serverUrl, next) {
 function open(browserName, serverUrl, next) {
   if (_injectedDriver) {
     console.log('Using injected driver.');
-    next(null, _injectedDriver);
+    next(null, _injectedDriver());
     return;
   }
 


### PR DESCRIPTION
I forgot a little thing. When you run f.e.: record, recoding creates an instance of webdriver and after calls method quit() after recoding is complete. Then starts playback which creates a new instance of webdriver. Injected driver must be pass as anonymous function to get control of instances (as you can see in commit diff).
