### PR TITLE
Don't use the openDummy technique with injected drivers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ function _openRunAndClose(playbackInfos, openDummy, action, next) {
 
     runtimeConfig.config.driver = driver;
 
-    if (openDummy) {
+    if (openDummy && !driver.__huxleyInjectedDriver) {
       // TODO: pass a config obj instead.
       return browser.openDummy(browserName, serverUrl, function(err, dummyDriver) {
         process.on('SIGINT', function() {

--- a/source/browser/driver.js
+++ b/source/browser/driver.js
@@ -35,7 +35,9 @@ function _open(browserName, serverUrl, next) {
 function open(browserName, serverUrl, next) {
   if (_injectedDriver) {
     console.log('Using injected driver.');
-    next(null, _injectedDriver());
+    var injectedDriver = _injectedDriver();
+    injectedDriver.__huxleyInjectedDriver = true;
+    next(null, injectedDriver);
     return;
   }
 


### PR DESCRIPTION
I _think_ the entire technique may be able to be retired entirely since we're not taking screenshots of the whole browser ui, but just in case, this just disables it for external driver situations. We could also just reuse the 'driver' function and create a new injectedDriver, but in situations like in sauce or browserstack, this would spin up an entirely unrelated session.

More specifically, there's no guarantees of a `serverUrl` or anything when an external driver is being used. For me, this caused `ECONNREFUSED` errors in the dummy driver because it didn't have anywhere to connect.
