### PR TITLE
fix chrome bug in getBrowserName

### DIFF
--- a/source/browser/browser.js
+++ b/source/browser/browser.js
@@ -86,9 +86,9 @@ function getBrowserName(driver) {
   var prom = new Promise(function(resolve, reject) {
     driver
       .getCapabilities()
-      .then(function(whatIsThis) {
+      .then(function(res) {
         // damn it selenium, where's the js api docs
-        var browserName = whatIsThis.caps_.browserName;
+        var browserName = res.caps_ ? res.caps_.browserName : res.get('browserName')
         resolve(browserName);
       }, reject);
   });


### PR DESCRIPTION
When running with chromedriver (`hux --browser chrome`) I was getting an error:

```
TypeError: Cannot read property 'browserName' of undefined
```

Not sure if it's version-related, but in this case the argument is a [`Capabilities`](https://github.com/SeleniumHQ/selenium/blob/master/javascript/webdriver/capabilities.js#L169) object.
